### PR TITLE
Match Podman images including the tag

### DIFF
--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -646,8 +646,8 @@ bool docker_async_source::parse_docker(const docker_lookup_request& request, sin
 	string json;
 
 	g_logger.format(sinsp_logger::SEV_DEBUG,
-			"docker_async (%s): Looking up info for container",
-			request.container_id.c_str());
+			"docker_async (%s): Looking up info for container via socket %s",
+			request.container_id.c_str(), request.docker_socket.c_str());
 
 	std::string api_request = "/containers/" + request.container_id + "/json";
 	if(request.request_rw_size)


### PR DESCRIPTION
    If a container is started e.g. as `docker.io/library/httpd`,
    this is what ends up in container.m_image. Then we match m_image
    against the names on the container image list, but they always
    have a tag, e.g. `docker.io/library/httpd:latest` so they won't
    match the name without a tag.

    Fix it by:
    - defaulting to the `latest` tag a bit earlier (before fetching
      the image list)
    - using repo + ':' + tag as the string to match to always have
      the tag in the name to compare