### PR TITLE
Support sinsp::restart_capture_at_filepos for fd-based captures

### DIFF
--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -1040,7 +1040,18 @@ void sinsp::restart_capture_at_filepos(uint64_t filepos)
 	// Close and reopen the capture
 	//
 	m_file_start_offset = filepos;
+	int fd = m_input_fd;
+	if(fd > 0)
+	{
+		fd = dup(fd);
+		if(fd < 0)
+		{
+			throw sinsp_exception("Failed to copy fd " + std::to_string(m_input_fd) + ": " + strerror(errno));
+		}
+	}
 	close();
+	m_input_fd = fd;
+	lseek(fd, 0, SEEK_SET);
 	open_int();
 
 	//


### PR DESCRIPTION
When opening a capture based on a fd (e.g. sinsp::fdopen), we cannot
reopen the capture by simply calling close/open_int, as gzclose()
at the end of the call chain originating from close() closes the file
descriptor and we cannot access it again.

So when we're reopening a fd-based capture, dup() the original fd,
lseek() it to the beginning and substitute it for the closed one.
