### PR TITLE
Fix detecting containers started with image id instead of name

### DIFF
--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -572,6 +572,20 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 
 		// containers can be spawned using just the imageID as image name,
 		// with or without the hash prefix (e.g. sha256:)
+		//
+		// e.g. an image with the id `sha256:ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347`
+		// can be used to run a container as:
+		// - docker run sha256:ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347
+		// - docker run ddcca4b8a6f0367b5de2764dfe76b0a4bfa6d75237932185923705da47004347
+		// - docker run sha256:ddcca4
+		// - docker run ddcca4
+		//
+		// in all these cases we need to determine the image repo/tag
+		// via the API (in `fetch_image_info()`)
+		//
+		// otherwise we assume the name passed to `docker run`
+		// (available in container.m_image) is the repo name like `redis`
+		// and use that to determine the name and tag
 		bool no_name = sinsp_utils::startswith(container.m_imageid, container.m_image) ||
 			       sinsp_utils::startswith(imgstr, container.m_image);
 

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -572,8 +572,8 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 
 		// containers can be spawned using just the imageID as image name,
 		// with or without the hash prefix (e.g. sha256:)
-		bool no_name = sinsp_utils::startswith(container.m_image, container.m_imageid) ||
-			       sinsp_utils::startswith(container.m_image, imgstr);
+		bool no_name = sinsp_utils::startswith(container.m_imageid, container.m_image) ||
+			       sinsp_utils::startswith(imgstr, container.m_image);
 
 		if(!no_name || !m_query_image_info)
 		{

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -572,8 +572,8 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 
 		// containers can be spawned using just the imageID as image name,
 		// with or without the hash prefix (e.g. sha256:)
-		bool no_name = !sinsp_utils::startswith(container.m_image, container.m_imageid) &&
-			       !sinsp_utils::startswith(container.m_image, imgstr);
+		bool no_name = sinsp_utils::startswith(container.m_image, container.m_imageid) ||
+			       sinsp_utils::startswith(container.m_image, imgstr);
 
 		if(!no_name || !m_query_image_info)
 		{

--- a/userspace/libsinsp/container_engine/docker/async_source.cpp
+++ b/userspace/libsinsp/container_engine/docker/async_source.cpp
@@ -602,7 +602,7 @@ void docker_async_source::get_image_info(const docker_lookup_request& request, s
 	{
 		// a '/' is present in the Image field. Parse it into parts
 		std::string hostname, port;
-		sinsp_utils::split_container_image(container.m_image,
+		sinsp_utils::split_container_image(imgstr,
 						   hostname,
 						   port,
 						   container.m_imagerepo,


### PR DESCRIPTION
###    Extend the comment about running containers with image ids

###    Flip the parameters to `startswith` when comparing image ids

    The image id (with or without the `sha256:` prefix) is at least
    as long as the requested image id (which can be a substring
    of the full id), so the proper logic is "does the full id
    start with the requested id", not the other way round.

###    Fix inverted logic when checking whether image name is the id

    This got broken when adding Podman support. The original code involved
    multiple layers negations and while trying to understand the code,
    I got the logic wrong. This got exposed when running a container
    using the image id instead of the image name: we mistakenly reported
    the image repo/tag as sha256/<image id>.

###    Split the right image id for podman containers

    While these two are apparently always the same, we check .Image
    for the '/' and then we parse .Config.Image.

    Switch to parsing .Image for somewhat reduced confusion.