### PR TITLE
Changes needed for Sysdig agent to support aarch64 (64-bit ARM) and s390x (zLinux) architectures

### DIFF
--- a/cmake/modules/protobuf.cmake
+++ b/cmake/modules/protobuf.cmake
@@ -30,7 +30,6 @@ else()
 				DEPENDS openssl zlib
 				URL "http://download.sysdig.com/dependencies/protobuf-cpp-3.5.0.tar.gz"
 				URL_MD5 "e4ba8284a407712168593e79e6555eb2"
-				PATCH_COMMAND wget http://download.sysdig.com/dependencies/protobuf-3.5.0-s390x.patch && patch -p1 -i protobuf-3.5.0-s390x.patch
 				# TODO what if using system zlib?
 				CONFIGURE_COMMAND /usr/bin/env CPPFLAGS=-I${ZLIB_INCLUDE} LDFLAGS=-L${ZLIB_SRC} ./configure --with-zlib --disable-shared --enable-static --prefix=${PROTOBUF_INSTALL_DIR}
 				COMMAND aclocal && automake

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -16,6 +16,7 @@ or GPL2.txt for full copies of the license.
 #include <linux/in.h>
 #include <linux/fdtable.h>
 #include <linux/net.h>
+#include <endian.h>
 
 #include "../ppm_flag_helpers.h"
 #include "builtins.h"
@@ -390,6 +391,7 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 		if (lookahead_size >= 5) {
 			u32 buf = *(u32 *)&get_buf(0);
 
+#if __BYTE_ORDER == __LITTLE_ENDIAN
 			if (buf == 0x20544547 || // "GET "
 			    buf == 0x54534F50 || // "POST"
 			    buf == 0x20545550 || // "PUT "
@@ -400,6 +402,20 @@ static __always_inline u32 bpf_compute_snaplen(struct filler_data *data,
 			    (buf == 0x50545448 && data->buf[(data->state->tail_ctx.curoff + 4) & SCRATCH_SIZE_HALF] == '/')) { // "HTTP/"
 				return 2000;
 			}
+#elif __BYTE_ORDER == __BIG_ENDIAN
+			if (buf == 0x47455420 || // "GET "
+			    buf == 0x504F5354 || // "POST"
+			    buf == 0x50555420 || // "PUT "
+			    buf == 0x44454C45 || // "DELE"
+			    buf == 0x54524143 || // "TRAC"
+			    buf == 0x434F4E4E || // "CONN"
+			    buf == 0x4F505449 || // "OPTI"
+			    (buf == 0x48545450 && data->buf[(data->state->tail_ctx.curoff + 4) & SCRATCH_SIZE_HALF] == '/')) { // "HTTP/"
+				return 2000;
+			}
+#else
+#error UNDEFINED __BYTE_ORDER
+#endif
 		}
 	}
 
@@ -719,6 +735,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 {
 	unsigned int len_dyn = 0;
 	unsigned int len;
+	volatile unsigned long off;
 
 	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
 		return PPM_FAILURE_BUFFER_FULL;
@@ -730,9 +747,6 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		data->state->tail_ctx.len += len_dyn;
 	}
 
-	if (data->state->tail_ctx.curoff > SCRATCH_SIZE_HALF)
-		return PPM_FAILURE_BUFFER_FULL;
-
 	switch (type) {
 	case PT_CHARBUF:
 	case PT_FSPATH:
@@ -740,7 +754,10 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 		if (!data->curarg_already_on_frame) {
 			int res;
 
-			res = bpf_probe_read_str(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+			off = data->state->tail_ctx.curoff;
+			if (off > SCRATCH_SIZE_HALF)
+				return PPM_FAILURE_BUFFER_FULL;
+			res = bpf_probe_read_str(&data->buf[off & SCRATCH_SIZE_HALF],
 						 PPM_MAX_ARG_SIZE,
 						 (const void *)val);
 			if (res == -EFAULT)
@@ -764,14 +781,17 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 
 				if (!data->curarg_already_on_frame) {
 					volatile unsigned long read_size = dpi_lookahead_size;
+					off = data->state->tail_ctx.curoff;
+					if (off > SCRATCH_SIZE_HALF)
+						return PPM_FAILURE_BUFFER_FULL;
 
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 					if (read_size)
-						if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+						if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
 								   ((read_size - 1) & SCRATCH_SIZE_HALF) + 1,
 								   (void *)val))
 #else
-					if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+					if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
 							   read_size & SCRATCH_SIZE_HALF,
 							   (void *)val))
 #endif
@@ -789,13 +809,16 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 			if (!data->curarg_already_on_frame) {
 				volatile unsigned long read_size = len;
 
+				off = data->state->tail_ctx.curoff;
+				if (off > SCRATCH_SIZE_HALF)
+					return PPM_FAILURE_BUFFER_FULL;
 #ifdef BPF_FORBIDS_ZERO_ACCESS
 				if (read_size)
-					if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+					if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
 							   ((read_size - 1) & SCRATCH_SIZE_HALF) + 1,
 							   (void *)val))
 #else
-				if (bpf_probe_read(&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF],
+				if (bpf_probe_read(&data->buf[off & SCRATCH_SIZE_HALF],
 						   read_size & SCRATCH_SIZE_HALF,
 						   (void *)val))
 #endif
@@ -821,13 +844,19 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	case PT_FLAGS8:
 	case PT_UINT8:
 	case PT_SIGTYPE:
-		*((u8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((u8 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(u8);
 		break;
 	case PT_FLAGS16:
 	case PT_UINT16:
 	case PT_SYSCALLID:
-		*((u16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((u16 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(u16);
 		break;
 	case PT_FLAGS32:
@@ -836,32 +865,50 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	case PT_UID:
 	case PT_GID:
 	case PT_SIGSET:
-		*((u32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((u32 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(u32);
 		break;
 	case PT_RELTIME:
 	case PT_ABSTIME:
 	case PT_UINT64:
-		*((u64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((u64 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(u64);
 		break;
 	case PT_INT8:
-		*((s8 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((s8 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(s8);
 		break;
 	case PT_INT16:
-		*((s16 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((s16 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(s16);
 		break;
 	case PT_INT32:
-		*((s32 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((s32 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(s32);
 		break;
 	case PT_INT64:
 	case PT_ERRNO:
 	case PT_FD:
 	case PT_PID:
-		*((s64 *)&data->buf[data->state->tail_ctx.curoff & SCRATCH_SIZE_HALF]) = val;
+		off = data->state->tail_ctx.curoff;
+		if (off > SCRATCH_SIZE_HALF)
+			return PPM_FAILURE_BUFFER_FULL;
+		*((s64 *)&data->buf[off & SCRATCH_SIZE_HALF]) = val;
 		len = sizeof(s64);
 		break;
 	default: {
@@ -878,6 +925,7 @@ static __always_inline int __bpf_val_to_ring(struct filler_data *data,
 	fixup_evt_arg_len(data->buf, data->state->tail_ctx.curarg, len_dyn + len);
 	data->state->tail_ctx.curoff += len;
 	data->state->tail_ctx.len += len;
+
 	data->curarg_already_on_frame = false;
 	++data->state->tail_ctx.curarg;
 
@@ -932,7 +980,7 @@ static __always_inline int bpf_val_to_ring_type(struct filler_data *data,
 
 static __always_inline bool bpf_in_ia32_syscall()
 {
-#ifdef __ppc64__
+#ifndef __x86_64__
 	return 0;
 #else
 	struct task_struct *task;
@@ -951,7 +999,7 @@ static __always_inline bool bpf_in_ia32_syscall()
 #endif
 
 	return status & TS_COMPAT;
-#endif // #ifdef __ppc64__
+#endif // #ifndef __x86_64__
 }
 
 #endif

--- a/driver/bpf/filler_helpers.h
+++ b/driver/bpf/filler_helpers.h
@@ -980,9 +980,7 @@ static __always_inline int bpf_val_to_ring_type(struct filler_data *data,
 
 static __always_inline bool bpf_in_ia32_syscall()
 {
-#ifndef __x86_64__
-	return 0;
-#else
+#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
 	struct task_struct *task;
 	u32 status;
 
@@ -999,7 +997,9 @@ static __always_inline bool bpf_in_ia32_syscall()
 #endif
 
 	return status & TS_COMPAT;
-#endif // #ifndef __x86_64__
+#else /* X86 */
+	return 0;
+#endif /* X86 */
 }
 
 #endif

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -24,8 +24,11 @@ or GPL2.txt for full copies of the license.
 #define BPF_FORBIDS_ZERO_ACCESS
 #endif
 
+/* RAW_TRACEPOINTS logic is x86-specific
+#ifdef __x86_64__
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
+#endif
 #endif
 
 /* Redefine asm_volatile_goto to work around clang not supporting it

--- a/driver/bpf/quirks.h
+++ b/driver/bpf/quirks.h
@@ -25,7 +25,7 @@ or GPL2.txt for full copies of the license.
 #endif
 
 /* RAW_TRACEPOINTS logic is x86-specific
-#ifdef __x86_64__
+#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #define BPF_SUPPORTS_RAW_TRACEPOINTS
 #endif

--- a/userspace/chisel/chisel.cpp
+++ b/userspace/chisel/chisel.cpp
@@ -43,6 +43,7 @@ limitations under the License.
 #ifdef HAS_LUA_CHISELS
 
 extern "C" {
+#define LUA_COMPAT_ALL
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
@@ -95,7 +96,7 @@ void lua_stackdump(lua_State *L)
 // Lua callbacks
 ///////////////////////////////////////////////////////////////////////////////
 #ifdef HAS_LUA_CHISELS
-const static struct luaL_reg ll_sysdig [] =
+const static struct luaL_Reg ll_sysdig [] =
 {
 	{"set_filter", &lua_cbacks::set_global_filter},
 	{"set_snaplen", &lua_cbacks::set_snaplen},
@@ -131,7 +132,7 @@ const static struct luaL_reg ll_sysdig [] =
 	{NULL,NULL}
 };
 
-const static struct luaL_reg ll_chisel [] =
+const static struct luaL_Reg ll_chisel [] =
 {
 	{"request_field", &lua_cbacks::request_field},
 	{"set_filter", &lua_cbacks::set_filter},
@@ -143,7 +144,7 @@ const static struct luaL_reg ll_chisel [] =
 	{NULL,NULL}
 };
 
-const static struct luaL_reg ll_evt [] =
+const static struct luaL_Reg ll_evt [] =
 {
 	{"field", &lua_cbacks::field},
 	{"get_num", &lua_cbacks::get_num},
@@ -960,7 +961,7 @@ bool sinsp_chisel::parse_view_info(lua_State *ls, OUT chisel_desc* cd)
 // Initializes a lua chisel
 bool sinsp_chisel::init_lua_chisel(chisel_desc &cd, string const &fpath)
 {
-	lua_State* ls = lua_open();
+	lua_State* ls = luaL_newstate();
 	if(ls == NULL)
 	{
 		return false;
@@ -1201,7 +1202,7 @@ void sinsp_chisel::load(string cmdstr)
 	//
 	// Open the script
 	//
-	m_ls = lua_open();
+	m_ls = luaL_newstate();
 
 	luaL_openlibs(m_ls);
 

--- a/userspace/chisel/chisel_api.cpp
+++ b/userspace/chisel/chisel_api.cpp
@@ -44,6 +44,7 @@ limitations under the License.
 
 #ifdef HAS_LUA_CHISELS
 extern "C" {
+#define LUA_COMPAT_ALL
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"

--- a/userspace/chisel/lua_parser.cpp
+++ b/userspace/chisel/lua_parser.cpp
@@ -25,12 +25,13 @@ limitations under the License.
 
 
 extern "C" {
+#define LUA_COMPAT_ALL
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
 }
 
-const static struct luaL_reg ll_filter [] =
+const static struct luaL_Reg ll_filter [] =
 {
 	{"rel_expr", &lua_parser_cbacks::rel_expr},
 	{"bool_op", &lua_parser_cbacks::bool_op},

--- a/userspace/chisel/lua_parser_api.cpp
+++ b/userspace/chisel/lua_parser_api.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include "lua_parser.h"
 
 extern "C" {
+#define LUA_COMPAT_ALL
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
@@ -264,7 +265,7 @@ int lua_parser_cbacks::rel_expr(lua_State *ls)
 					string err = "Got non-table as in-expression operand for field " + string(fld);
 					throw sinsp_exception(err);
 				}
-				int n = luaL_getn(ls, 4);  /* get size of table */
+				int n = (int)lua_objlen(ls, 4);  /* get size of table */
 				for (i=1; i<=n; i++)
 				{
 					lua_rawgeti(ls, 4, i);

--- a/userspace/libsinsp/ifinfo.h
+++ b/userspace/libsinsp/ifinfo.h
@@ -19,8 +19,6 @@ limitations under the License.
 
 #include "tuples.h"
 
-#define LOOPBACK_ADDR 0x0100007f
-
 #ifndef VISIBILITY_PRIVATE
 #define VISIBILITY_PRIVATE private:
 #endif


### PR DESCRIPTION
- Expand use of existing techniques (volatile variables, masking) to get
  kernel verifier to accept eBPF probe on aarch64
- Fix Little-Endian byte-ordering assumptions in HTTP parsing and IP address
  validation code
- Adjust set of LUA APIs used, to allow interoperability with the different LUA
  versions available for the different architectures

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

/area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Changes needed to allow Sysdig agent to run on aarch64 and s390x architectures.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
