### PR TITLE
fix(driver/bpf): use always-y instead of always

### DIFF
--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -5,7 +5,9 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
-always += probe.o
+always-y += probe.o
+# kept for compatibility with kernels < 5.11
+always = $(always-y)
 
 LLC ?= llc
 CLANG ?= clang


### PR DESCRIPTION
cherry-pick of: https://github.com/falcosecurity/libs/pull/59