### PR TITLE
Pull upcoming falcosecurity/libs driver eventmask changes

### DIFF
--- a/driver/bpf/probe.c
+++ b/driver/bpf/probe.c
@@ -59,6 +59,9 @@ BPF_PROBE("raw_syscalls/", sys_enter, sys_enter_args)
 	if (!sc_evt)
 		return 0;
 
+	if (sc_evt->flags & UF_UNINTERESTING)
+		return 0;
+
 	if (sc_evt->flags & UF_USED) {
 		evt_type = sc_evt->enter_event_type;
 		drop_flags = sc_evt->flags;
@@ -106,6 +109,9 @@ BPF_PROBE("raw_syscalls/", sys_exit, sys_exit_args)
 
 	sc_evt = get_syscall_info(id);
 	if (!sc_evt)
+		return 0;
+
+	if (sc_evt->flags & UF_UNINTERESTING)
 		return 0;
 
 	if (sc_evt->flags & UF_USED) {

--- a/driver/ppm.h
+++ b/driver/ppm.h
@@ -87,6 +87,7 @@ struct ppm_consumer_t {
 	uint16_t fullcapture_port_range_start;
 	uint16_t fullcapture_port_range_end;
 	uint16_t statsd_port;
+	DECLARE_BITMAP(events_mask, PPM_EVENT_MAX);
 };
 #endif // UDIG
 

--- a/driver/ppm_events_public.h
+++ b/driver/ppm_events_public.h
@@ -1571,8 +1571,10 @@ enum syscall_flags {
 	UF_USED = (1 << 0),
 	UF_NEVER_DROP = (1 << 1),
 	UF_ALWAYS_DROP = (1 << 2),
-	UF_SIMPLEDRIVER_KEEP = (1 << 3),
+	UF_SIMPLEDRIVER_KEEP = (1 << 3), ///< Mark a syscall to be kept in simpledriver mode, see scap_enable_simpledriver_mode()
 	UF_ATOMIC = (1 << 4), ///< The handler should not block (interrupt context)
+	UF_UNINTERESTING = (1 << 5), ///< Marks a syscall as not interesting. Currently only used by BPF probe to avoid tracing uninteresting syscalls.
+				     ///< Kmod uses a different logic path as we communicate with it through ioctls
 };
 
 struct syscall_evt_pair {

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -178,6 +178,8 @@ struct scap
 	// matching an entry in m_suppressed_comms.
 	uint64_t m_num_suppressed_evts;
 
+	bool syscalls_of_interest[SYSCALL_TABLE_SIZE];
+
 	//
 	// Plugin-related state
 	//

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -352,6 +352,29 @@ scap_t* scap_open_live_int(char *error, int32_t *rc,
 		return NULL;
 	}
 
+	// Special case -- force fallback path if all syscalls are enabled.
+	// This works around the following situation:
+	// - g_syscall_code_routing_table[] is incomplete
+	// - It does not contain an entry for execve or umount2 (and possibly others)
+	// - so, syscalls_of_interest builder below fails to enable those system calls
+	if (ppm_sc_of_interest)
+	{
+		bool all_set = true;
+		for (int i = 0; i < PPM_SC_MAX; i++)
+		{
+			if (!ppm_sc_of_interest->ppm_sc[i])
+			{
+				all_set = false;
+				break;
+			}
+		}
+
+		if (all_set)
+		{
+			ppm_sc_of_interest = NULL;
+		}
+	}
+
 	if (ppm_sc_of_interest)
 	{
 		for (int i = 0; i < PPM_SC_MAX; i++)

--- a/userspace/libscap/scap.h
+++ b/userspace/libscap/scap.h
@@ -309,6 +309,15 @@ typedef enum {
 	SCAP_MODE_PLUGIN,
 } scap_mode_t;
 
+/*!
+  \brief Argument for scap_open
+  Set any PPM_SC syscall idx to true to enable its tracing at driver level,
+  otherwise syscalls are not traced (so called "uninteresting syscalls").
+*/
+typedef struct {
+	bool ppm_sc[PPM_SC_MAX];
+} interesting_ppm_sc_set;
+
 typedef struct scap_open_args
 {
 	scap_mode_t mode;
@@ -324,6 +333,8 @@ typedef struct scap_open_args
 	                                                         // You can provide additional comm
 	                                                         // values via scap_suppress_events_comm().
 	bool udig; ///< If true, UDIG will be used for event capture. Otherwise, the kernel driver will be used.
+	interesting_ppm_sc_set ppm_sc_of_interest;
+
 	source_plugin_info* input_plugin; ///< use this to configure a source plugin that will produce the events for this capture
 	char* input_plugin_params; ///< optional parameters string for the source plugin pointed by src_plugin
 	void(*debug_log_fn)(const char* msg); // Function which SCAP may use to log a debug message

--- a/userspace/libscap/scap_bpf.c
+++ b/userspace/libscap/scap_bpf.c
@@ -768,11 +768,17 @@ static int32_t populate_syscall_routing_table_map(scap_t *handle)
 
 static int32_t populate_syscall_table_map(scap_t *handle)
 {
+	static const struct syscall_evt_pair uninterested_pair = { .flags = UF_UNINTERESTING };
 	int j;
 
 	for(j = 0; j < SYSCALL_TABLE_SIZE; ++j)
 	{
 		const struct syscall_evt_pair *p = &g_syscall_table[j];
+		if (!handle->syscalls_of_interest[j])
+		{
+			p = &uninterested_pair;
+		}
+
 		if(bpf_map_update_elem(handle->m_bpf_map_fds[SYSDIG_SYSCALL_TABLE], &j, p, BPF_ANY) != 0)
 		{
 			snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "SYSDIG_SYSCALL_TABLE bpf_map_update_elem < 0");
@@ -780,7 +786,7 @@ static int32_t populate_syscall_table_map(scap_t *handle)
 		}
 	}
 
-	return bpf_map_freeze(handle->m_bpf_map_fds[SYSDIG_SYSCALL_TABLE]);
+	return SCAP_SUCCESS;
 }
 
 static int32_t populate_event_table_map(scap_t *handle)
@@ -1486,4 +1492,53 @@ int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret)
 	}
 
 	return SCAP_SUCCESS;
+}
+
+int32_t scap_bpf_set_simple_mode(scap_t* handle)
+{
+	int j;
+	for(j = 0; j < SYSCALL_TABLE_SIZE; ++j)
+	{
+		const struct syscall_evt_pair *p = &g_syscall_table[j];
+		if(!(p->flags & UF_SIMPLEDRIVER_KEEP))
+		{
+			handle->syscalls_of_interest[j] = false;
+		}
+	}
+	return populate_syscall_table_map(handle);
+}
+
+int32_t scap_bpf_handle_event_mask(scap_t *handle, uint32_t op, uint32_t event_id) {
+	int j;
+	bool quit = false;
+	for(j = 0; j < SYSCALL_TABLE_SIZE && !quit; ++j)
+	{
+		/*
+		 * In case PPM_IOCTL_MASK_ZERO_EVENTS is called, event_id will be 0. Set every syscall to false in that case.
+		 * Otherwise, check {enter,exit} event for each syscall to see if it matches the requested event_id.
+		 */
+		if (event_id == 0 || g_syscall_table[j].enter_event_type == event_id || g_syscall_table[j].exit_event_type == event_id)
+		{
+			switch(op)
+			{
+			case PPM_IOCTL_MASK_ZERO_EVENTS:
+				handle->syscalls_of_interest[j] = false;
+				break;
+			case PPM_IOCTL_MASK_SET_EVENT:
+				handle->syscalls_of_interest[j] = true;
+				quit = true;
+				break;
+			case PPM_IOCTL_MASK_UNSET_EVENT:
+				handle->syscalls_of_interest[j] = false;
+				quit = true;
+				break;
+			default:
+				snprintf(handle->m_lasterr, SCAP_LASTERR_SIZE, "%s(%d) internal error", __FUNCTION__, op);
+				ASSERT(false);
+				return SCAP_FAILURE;
+				break;
+			}
+		}
+	}
+	return populate_syscall_table_map(handle);
 }

--- a/userspace/libscap/scap_bpf.h
+++ b/userspace/libscap/scap_bpf.h
@@ -46,6 +46,8 @@ int32_t scap_bpf_stop_dropping_mode(scap_t* handle);
 int32_t scap_bpf_enable_tracers_capture(scap_t* handle);
 int32_t scap_bpf_get_stats(scap_t* handle, OUT scap_stats* stats);
 int32_t scap_bpf_get_n_tracepoint_hit(scap_t* handle, long* ret);
+int32_t scap_bpf_set_simple_mode(scap_t* handle);
+int32_t scap_bpf_handle_event_mask(scap_t *handle, uint32_t op, uint32_t event_id);
 
 static inline scap_evt *scap_bpf_evt_from_perf_sample(void *evt)
 {

--- a/userspace/libsinsp/filter.cpp
+++ b/userspace/libsinsp/filter.cpp
@@ -1895,7 +1895,6 @@ sinsp_filter* sinsp_filter_compiler::compile()
 sinsp_filter* sinsp_filter_compiler::compile_()
 {
 	m_scansize = (uint32_t)m_fltstr.size();
-
 	while(true)
 	{
 		char a = next();
@@ -2027,8 +2026,6 @@ sinsp_filter* sinsp_filter_compiler::compile_()
 			break;
 		}
 	}
-
-	vector<string> components = sinsp_split(m_fltstr, ' ');
 	return m_filter;
 }
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -61,7 +61,7 @@ limitations under the License.
 #include <map>
 #include <queue>
 #include <vector>
-#include <set>
+#include <unordered_set>
 #include <list>
 #include <memory>
 
@@ -431,7 +431,6 @@ public:
 	 *        Value of SCAP_PROC_SCAN_LOGUT_NONE (default) means no logging.
 	 */
 	void set_proc_scan_log_interval_ms(uint64_t val);
-
 
 	/*!
 	  \brief Start writing the captured events to file.
@@ -893,6 +892,13 @@ public:
 
 	sinsp_parser* get_parser();
 
+	/*!
+	  \brief Enables simple_consumer mode on sinsp, at driver level.
+	  This will avoid tracing syscalls flagged with EF_DROP_SIMPLE_CONS.
+	  Must be called before sinsp opening.
+	*/
+	void set_simple_consumer();
+
 	bool setup_cycle_writer(std::string base_file_name, int rollover_mb, int duration_seconds, int file_limit, unsigned long event_limit, bool compress);
 	void import_ipv4_interface(const sinsp_ipv4_ifinfo& ifinfo);
 	void add_meta_event(sinsp_evt *metaevt);
@@ -996,7 +1002,7 @@ private:
 	void import_ifaddr_list();
 	void import_user_list();
 	void add_protodecoders();
-
+	void fill_syscalls_of_interest(scap_open_args *oargs);
 	void remove_thread(int64_t tid, bool force);
 
 	//
@@ -1048,6 +1054,8 @@ private:
 	scap_t* m_h;
 	uint64_t m_nevts;
 	int64_t m_filesize;
+
+	bool m_simpleconsumer;
 
 	scap_mode_t m_mode = SCAP_MODE_NONE;
 
@@ -1143,8 +1151,8 @@ public:
 	sinsp_filter* m_filter;
 	sinsp_evttype_filter *m_evttype_filter;
 	std::string m_filterstring;
-
 #endif
+	unordered_set<uint32_t> m_ppm_sc_of_interest;
 
 	//
 	// Internal stats


### PR DESCRIPTION
- Kernel module driver: Implements per-consumer eventmasks
- eBPF probe: Implements eventmasks

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

/area driver-kmod

/area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Fixes sysdig agent problem with skip_events_by_type does not work intermittently under kernel mode driver.
Also enables support for skip_events_by_type under eBPF probe.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
Sysdig agent skip_events_by_type feature is currently supported only under kernel module driver mode, not with the eBPF probe.  And there is a bug in the kernel module support, such that the specified events (e.g. system calls) to skip is sometimes not honored.  With this fix, the feature will be supported correctly, under both kernel module and eBPF prove modes.
```
