### PR TITLE
Handle CONTAINER_JSON_2 evts for special user.name handling

### DIFF
--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -4720,7 +4720,8 @@ uint8_t* sinsp_filter_check_user::extract(sinsp_evt *evt, OUT uint32_t* len, boo
 	}
 
 	// For container events, use the user from the container metadata instead.
-	if(m_field_id == TYPE_NAME && evt->get_type() == PPME_CONTAINER_JSON_E)
+	if(m_field_id == TYPE_NAME &&
+	   (evt->get_type() == PPME_CONTAINER_JSON_E || evt->get_type() == PPME_CONTAINER_JSON_2_E))
 	{
 		const sinsp_container_info::ptr_t container_info =
 			m_inspector->m_container_manager.get_container(tinfo->m_container_id);


### PR DESCRIPTION
When doing the special handling for user.name and container events,
also handle PPME_CONTAINER_JSON_2, which was added in
https://github.com/falcosecurity/libs/pull/118.

That PR looked for all references to PPME_CONTAINER_JSON and updated
them to also handle PPME_CONTAINER_JSON_2, but as this special
handling is *only* in agent-libs, it was missed.
