### PR TITLE
Compile eBPF probe with -Wno-unknown-attributes

### DIFF
--- a/driver/bpf/Makefile
+++ b/driver/bpf/Makefile
@@ -48,5 +48,6 @@ $(obj)/probe.o: $(src)/probe.c \
 		-fno-jump-tables \
 		-fno-stack-protector \
 		-Wno-tautological-compare \
+		-Wno-unknown-attributes \
 		-O2 -g -emit-llvm -c $< -o $(patsubst %.o,%.ll,$@)
 	$(LLC) -march=bpf -filetype=obj -o $@ $(patsubst %.o,%.ll,$@)


### PR DESCRIPTION
Sysdig agent containers use clang-7 to build the eBPF probe.
That version of clang is too old to support some of the compiler
attributes which appear in the source code for more modern kernel
versions.  So disable warnings associated with unknown attributes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area driver-kmod

/area driver-ebpf

> /area libscap

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Build eBPF probe with -Wno-unknown-attributes, to avoid thousands of compiler
warnings due to presence of compiler attribute directives which have been defined
since the version of clang (v7.0.1) used in Sysdig product images.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
