### PR TITLE
Enable CLONE_EXIT_TO_CHILD workaround on s390x

### DIFF
--- a/userspace/libsinsp/sinsp_cpuarch.h
+++ b/userspace/libsinsp/sinsp_cpuarch.h
@@ -20,10 +20,13 @@ limitations under the License.
 #define LIBSINSP_CPUARCH_THREAD_EVENT_BUG_UNRELIABLE_CLONE_EXIT_EVENT_TO_CHILD    (1 << 0)
 #define LIBSINSP_CPUARCH_THREAD_EVENT_BUG_UNRELIABLE_EXECVE_EXIT_EVENT_ON_SUCCESS (1 << 1)
 
-#ifdef __aarch64__
+#if defined(__aarch64__)
 #define LIBSINSP_CPUARCH_THREAD_EVENT_BUGS                                               ( \
                LIBSINSP_CPUARCH_THREAD_EVENT_BUG_UNRELIABLE_CLONE_EXIT_EVENT_TO_CHILD |    \
                LIBSINSP_CPUARCH_THREAD_EVENT_BUG_UNRELIABLE_EXECVE_EXIT_EVENT_ON_SUCCESS )
+#elif defined(__s390x__)
+#define LIBSINSP_CPUARCH_THREAD_EVENT_BUGS                                               ( \
+               LIBSINSP_CPUARCH_THREAD_EVENT_BUG_UNRELIABLE_CLONE_EXIT_EVENT_TO_CHILD    )
 #else
 #define LIBSINSP_CPUARCH_THREAD_EVENT_BUGS 0
 #endif


### PR DESCRIPTION
zLinux (Linux on s390x) does not generate CLONE_EXIT_TO_CHILD ptrace events.
Enable the existing workaround for this misbehavior, for the s390x platform.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
zLinux (Linux on s390x) does not generate CLONE_EXIT_TO_CHILD ptrace events.
Enable the existing workaround for this misbehavior, for the s390x platform.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
