### PR TITLE
[SMAGENT-3578] Fix logic to recognize and avoid reporting expected TID collisions

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1387,7 +1387,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 
 			// Examine state of child, determine if the deleted child
 			// is fully-populated, for collision reporting below.
-			if(child->m_comm != "<NA>" && ptinfo->m_uid != 0xffffffff)
+			if(child->m_comm != "<NA>" && child->m_uid != 0xffffffff)
 			{
 				tid_collision_valid_child = true;
 			}


### PR DESCRIPTION
On ARM and s390x platforms, Linux ptrace fails to report CLONE_EXIT_TO_CHILD events.  Workaround logic may trigger TID collision logic in CLONE_EXIT_TO_PARENT handler, for certain expected cases.  In these expected cases, We want the benefits of the TID collision logic -- deleting and replacing partially-populated child threadinfo, but not the TID collision logging and watchdog timer behavior.  The logic to detect these expected cases and avoid the logging, had a bug that caused some expected cases to not be detected.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area driver-kmod

> /area driver-ebpf

> /area libscap

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Fix logic in ARM/s390x CLONE_EXIT_TO_CHILD event workaround, to correctly detect and avoid reporting of expected TID collisions.
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
