### PR TITLE
[SSPROD-18038] read exepath from /proc as the true source

### DIFF
--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -2166,123 +2166,142 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 	 * we can do nothing.
 	 */
 	if((etype == PPME_SYSCALL_EXECVE_18_X ||
-	    etype == PPME_SYSCALL_EXECVE_19_X)
-		&&
-		retrieve_enter_event(enter_evt, evt))
+	    etype == PPME_SYSCALL_EXECVE_19_X))
 	{
 		char fullpath[SCAP_MAX_PATH_SIZE] = {0};
-	
-		/* We need to manage the 2 possible cases:
-		 * - enter event is an `EXECVE`
-		 * - enter event is an `EXECVEAT`
-		 */
-		if(enter_evt->get_type() == PPME_SYSCALL_EXECVE_18_E ||
-		   enter_evt->get_type() == PPME_SYSCALL_EXECVE_19_E)
+		char buf[SCAP_MAX_PATH_SIZE] = {0};
+		snprintf(buf,
+			 sizeof(buf),
+			 "%s/proc/%s/exe",
+			 scap_get_host_root(),
+			 std::to_string(evt->m_tinfo->m_pid).c_str());
+
+		int n = readlink(buf, fullpath, sizeof(fullpath));
+		if(n >= 0)
 		{
-			/*
-			 * Get filename
-			 */
-			parinfo = enter_evt->get_param(0);
-			/* This could happen only if we are not able to get the info from the kernel,
-			 * because if the syscall was successful the pathname was surely here the problem
-			 * is that for some reason we were not able to get it with our instrumentation, 
-			 * for example when the `bpf_probe_read()` call fails in BPF.
-			 */
-			if(strncmp(parinfo->m_val, "<NA>", 5) == 0)
+			if(n == sizeof(fullpath))
 			{
-				strncpy(fullpath, "<NA>", 5);
+				n--;
 			}
-			else
-			{
-				/* Here the filename can be relative or absolute. */
-				sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
-												evt->m_tinfo->m_cwd.c_str(),
-												(uint32_t)evt->m_tinfo->m_cwd.size(),
-												parinfo->m_val,
-												(uint32_t)parinfo->m_len,
-												m_inspector->m_is_windows);
-			}
+			fullpath[n] = '\0';
 		}
-		else if(enter_evt->get_type() == PPME_SYSCALL_EXECVEAT_E)
+		else //can't read from /proc, read from the event params
 		{
-			/*
-			 * Get dirfd
-			 */
-			parinfo = enter_evt->get_param(0);
-			ASSERT(parinfo->m_len == sizeof(int64_t));
-			int64_t dirfd = *(int64_t *)parinfo->m_val;
-			
-			/*
-			 * Get flags
-			 */
-			parinfo = enter_evt->get_param(2);
-			ASSERT(parinfo->m_len == sizeof(uint32_t));
-			uint32_t flags = *(uint32_t *)parinfo->m_val;
-
-			/*
-			 * Get pathname
-			 */
-
-			/* The pathname could be:
-			 * - (1) relative (to dirfd).
-			 * - (2) absolute.
-			 * - (3) empty in the kernel because the user specified the `AT_EMPTY_PATH` flag.
-			 *   In this case, `dirfd` must refer to a file.
-			 *   Please note:
-			 *   The path is empty in the kernel but in userspace, we will obtain a `<NA>`.
-			 * - (4) empty in the kernel because we fail to recover it from the registries.
-			 * 	 Please note:
-			 *   The path is empty in the kernel but in userspace, we will obtain a `<NA>`.
-			 */
-			parinfo = enter_evt->get_param(1);
-			char *pathname = parinfo->m_val;
-			uint32_t namelen = parinfo->m_len;
-
-			/* If the pathname is `<NA>` here we shouldn't have problems during `parse_dirfd`.
-			 * It doesn't start with "/" so it is not considered an absolute path.
-			 */
-			string sdir;
-			parse_dirfd(evt, pathname, dirfd, &sdir);
-
-			/* (4) In this case, we were not able to recover the pathname from the kernel or 
-			 * we are not able to recover information about `dirfd` in our `sinsp` state.
-			 * Fallback to `<NA>`.
-			 */
-			if((!(flags & PPM_EXVAT_AT_EMPTY_PATH) && strncmp(pathname, "<NA>", 5) == 0) ||
-			   sdir.compare("<UNKNOWN>") == 0)
+			if(retrieve_enter_event(enter_evt, evt))
 			{
-				/* we copy also the string terminator `\0`. */
-				strncpy(fullpath, "<NA>", 5);
-			} 
-			/* (3) In this case we have already obtained the `exepath` and it is `sdir`, we just need
-			 * to sanitize it. 
-			 */
-			else if(flags & PPM_EXVAT_AT_EMPTY_PATH)
-			{
-				/* We explicitly set the `pathlen` to `0`, since `pathname` is `<NA>` 
-				 * as we said in case (3), and we don't want to consider it as a valid
-				 * part of the final path. In this case `sdir` will always be 
-				 * an absolute path.
+
+				/* We need to manage the 2 possible cases:
+				 * - enter event is an `EXECVE`
+				 * - enter event is an `EXECVEAT`
 				 */
-				sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
-								"\0", 
-								0,
-								sdir.c_str(), 
-								(uint32_t)sdir.length(), 
-								m_inspector->m_is_windows);
+				if(enter_evt->get_type() == PPME_SYSCALL_EXECVE_18_E ||
+				   enter_evt->get_type() == PPME_SYSCALL_EXECVE_19_E)
+				{
+					/*
+			         * Get filename
+			         */
+					parinfo = enter_evt->get_param(0);
+					/* This could happen only if we are not able to get the info from the kernel,
+			         * because if the syscall was successful the pathname was surely here the problem
+			         * is that for some reason we were not able to get it with our instrumentation, 
+			         * for example when the `bpf_probe_read()` call fails in BPF.
+			         */
+					if(strncmp(parinfo->m_val, "<NA>", 5) == 0)
+					{
+						strncpy(fullpath, "<NA>", 5);
+					}
+					else
+					{
+						/* Here the filename can be relative or absolute. */
+						sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									       evt->m_tinfo->m_cwd.c_str(),
+									       (uint32_t)evt->m_tinfo->m_cwd.size(),
+									       parinfo->m_val,
+									       (uint32_t)parinfo->m_len,
+									       m_inspector->m_is_windows);
+					}
+				}
+				else if(enter_evt->get_type() == PPME_SYSCALL_EXECVEAT_E)
+				{
+					/*
+			         * Get dirfd
+			         */
+					parinfo = enter_evt->get_param(0);
+					ASSERT(parinfo->m_len == sizeof(int64_t));
+					int64_t dirfd = *(int64_t *)parinfo->m_val;
 
-			}
-			/* (2)/(1) If it is relative or absolute we craft the `fullpath` as usual:
-			 * - `sdir` + `pathname`
-			 */
-			else
-			{
-				sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
-											sdir.c_str(), 
-											(uint32_t)sdir.length(),
-											pathname, 
-											namelen, 
-											m_inspector->m_is_windows);
+					/*
+			         * Get flags
+			         */
+					parinfo = enter_evt->get_param(2);
+					ASSERT(parinfo->m_len == sizeof(uint32_t));
+					uint32_t flags = *(uint32_t *)parinfo->m_val;
+
+					/*
+			         * Get pathname
+			         */
+
+					/* The pathname could be:
+			         * - (1) relative (to dirfd).
+			         * - (2) absolute.
+			         * - (3) empty in the kernel because the user specified the `AT_EMPTY_PATH` flag.
+			         *   In this case, `dirfd` must refer to a file.
+			         *   Please note:
+			         *   The path is empty in the kernel but in userspace, we will obtain a `<NA>`.
+			         * - (4) empty in the kernel because we fail to recover it from the registries.
+			         * 	 Please note:
+			         *   The path is empty in the kernel but in userspace, we will obtain a `<NA>`.
+			         */
+					parinfo = enter_evt->get_param(1);
+					char *pathname = parinfo->m_val;
+					uint32_t namelen = parinfo->m_len;
+
+					/* If the pathname is `<NA>` here we shouldn't have problems during `parse_dirfd`.
+			         * It doesn't start with "/" so it is not considered an absolute path.
+			         */
+					string sdir;
+					parse_dirfd(evt, pathname, dirfd, &sdir);
+
+					/* (4) In this case, we were not able to recover the pathname from the kernel or 
+			         * we are not able to recover information about `dirfd` in our `sinsp` state.
+			         * Fallback to `<NA>`.
+			         */
+					if((!(flags & PPM_EXVAT_AT_EMPTY_PATH) && strncmp(pathname, "<NA>", 5) == 0) ||
+					   sdir.compare("<UNKNOWN>") == 0)
+					{
+						/* we copy also the string terminator `\0`. */
+						strncpy(fullpath, "<NA>", 5);
+					}
+					/* (3) In this case we have already obtained the `exepath` and it is `sdir`, we just need
+			         * to sanitize it. 
+			         */
+					else if(flags & PPM_EXVAT_AT_EMPTY_PATH)
+					{
+						/* We explicitly set the `pathlen` to `0`, since `pathname` is `<NA>` 
+				         * as we said in case (3), and we don't want to consider it as a valid
+				         * part of the final path. In this case `sdir` will always be 
+				         * an absolute path.
+				         */
+						sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									       "\0",
+									       0,
+									       sdir.c_str(),
+									       (uint32_t)sdir.length(),
+									       m_inspector->m_is_windows);
+					}
+					/* (2)/(1) If it is relative or absolute we craft the `fullpath` as usual:
+			         * - `sdir` + `pathname`
+			         */
+					else
+					{
+						sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE,
+									       sdir.c_str(),
+									       (uint32_t)sdir.length(),
+									       pathname,
+									       namelen,
+									       m_inspector->m_is_windows);
+					}
+				}
 			}
 		}
 		evt->m_tinfo->m_exepath = fullpath;


### PR DESCRIPTION
        When building threadinfo from execve event, use the /proc/<pid>/exe
        symlink to get the fullpath, reason being reading from the command args
        may result in the paths being symlinks, not the real paths.
        read from evt params only in case read from /proc is unsuccessful


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

> /area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
NONE
```
