### PR TITLE
fix: increase maximum number of retries to get container info from CRI

### DIFF
--- a/userspace/libsinsp/container_info.h
+++ b/userspace/libsinsp/container_info.h
@@ -89,7 +89,7 @@ public:
 			return false;
 		}
 
-		return m_retry < 3;
+		return m_retry < 5;
 	}
 
 	/**


### PR DESCRIPTION
This change increases the number of retries to retrieve container information from CRI API from 3 to 5, as several failures were observed with the maximum number of attempts set to 3.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area API-version

> /area build

> /area CI

> /area driver-kmod

> /area driver-bpf

> /area driver-modern-bpf

> /area libscap-engine-bpf

> /area libscap-engine-gvisor

> /area libscap-engine-kmod

> /area libscap-engine-modern-bpf

> /area libscap-engine-nodriver

> /area libscap-engine-noop

> /area libscap-engine-source-plugin

> /area libscap-engine-savefile

> /area libscap-engine-udig

> /area libscap

> /area libpman

/area libsinsp

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**Does this PR require a change in the driver versions?**

> /version driver-API-version-major

> /version driver-API-version-minor

> /version driver-API-version-patch

> /version driver-SCHEMA-version-major

> /version driver-SCHEMA-version-minor

> /version driver-SCHEMA-version-patch

<!--
Please remove the leading whitespace before the `/version <>` you uncommented.
-->

**What this PR does / why we need it**:

In a machine with the following specs:

```
$ containerd --version
containerd github.com/containerd/containerd v1.4.13 9cc61520f4cd876b86e77edfeb88fbcd536d1f9d
$ uname -a
Linux ip-172-20-60-120 5.15.0-1022-aws #26~20.04.1-Ubuntu SMP Sat Oct 15 03:22:07 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
$ curl http://169.254.169.254/latest/meta-data/instance-type && echo
m6a.xlarge
```

I observed several failures to retrieve the container information from the CRI API

```
2022-12-08 14:24:20.884, 348754.348781, Debug, cri (793bdb56be70): Performing lookup
2022-12-08 14:24:20.884, 348754.348781, Debug, cri_async (793bdb56be70): Starting asynchronous lookup
2022-12-08 14:24:21.042, 348754.353222, Debug, cri_async (793bdb56be70): Source dequeued key attempt=0
2022-12-08 14:24:21.042, 348754.353222, Debug, cri (793bdb56be70): Status from ContainerStatus: (an error occurred when try to find container "793bdb56be70": not found)
2022-12-08 14:24:21.043, 348754.353222, Debug, cri (793bdb56be70): id is neither a container nor a pod sandbox: an error occurred when try to find container "793bdb56be70": not found
2022-12-08 14:24:21.043, 348754.353222, Debug, cri (793bdb56be70): Failed to get metadata, returning successful=false
2022-12-08 14:24:21.043, 348754.353222, Debug, cri_async (793bdb56be70): lookup retry no. 1
2022-12-08 14:24:21.169, 348754.353222, Debug, cri_async (793bdb56be70): Source dequeued key attempt=1
2022-12-08 14:24:21.173, 348754.353222, Debug, cri (793bdb56be70): Status from ContainerStatus: (an error occurred when try to find container "793bdb56be70": not found)
2022-12-08 14:24:21.173, 348754.353222, Debug, cri (793bdb56be70): id is neither a container nor a pod sandbox: an error occurred when try to find container "793bdb56be70": not found
2022-12-08 14:24:21.173, 348754.353222, Debug, cri (793bdb56be70): Failed to get metadata, returning successful=false
2022-12-08 14:24:21.173, 348754.353222, Debug, cri_async (793bdb56be70): lookup retry no. 2
2022-12-08 14:24:21.424, 348754.353222, Debug, cri_async (793bdb56be70): Source dequeued key attempt=2
2022-12-08 14:24:21.427, 348754.353222, Debug, cri (793bdb56be70): Status from ContainerStatus: (an error occurred when try to find container "793bdb56be70": not found)
2022-12-08 14:24:21.427, 348754.353222, Debug, cri (793bdb56be70): id is neither a container nor a pod sandbox: an error occurred when try to find container "793bdb56be70": not found
2022-12-08 14:24:21.427, 348754.353222, Debug, cri (793bdb56be70): Failed to get metadata, returning successful=false
2022-12-08 14:24:21.427, 348754.353222, Debug, cri_async (793bdb56be70): lookup retry no. 3
2022-12-08 14:24:21.927, 348754.353222, Debug, cri_async (793bdb56be70): Source dequeued key attempt=3
2022-12-08 14:24:21.928, 348754.353222, Debug, cri (793bdb56be70): Status from ContainerStatus: (an error occurred when try to find container "793bdb56be70": not found)
2022-12-08 14:24:21.928, 348754.353222, Debug, cri (793bdb56be70): id is neither a container nor a pod sandbox: an error occurred when try to find container "793bdb56be70": not found
2022-12-08 14:24:21.928, 348754.353222, Debug, cri (793bdb56be70): Failed to get metadata, returning successful=false
2022-12-08 14:24:21.928, 348754.353222, Debug, cri_async (793bdb56be70): Could not look up container info after 3 retries
2022-12-08 14:24:21.928, 348754.353222, Debug, cri_async (793bdb56be70): Source callback result=2
```

Setting it to 5 I did not manage to reproduce the failure in the same environment.
A PR to make the retry and backoff settings configurable will follow.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, you have to do nothing.
If yes, a release note is required:
Delete `NONE` and enter your extended release note in the block below.
Please note, the release note follows the "conventional commit specification" (https://www.conventionalcommits.org/en/v1.0.0/):
For example: `fix: broken link`.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of libscap`.
-->

```release-note
fix: increase the maximum number of attempts to retrieve container information from CRI API from 3 to 5.
```
