### PR TITLE
new(scap): support no_events mode

### DIFF
--- a/userspace/libscap/engine/bpf/scap_bpf.c
+++ b/userspace/libscap/engine/bpf/scap_bpf.c
@@ -1763,6 +1763,11 @@ static int32_t configure(struct scap_engine_handle engine, enum scap_setting set
 
 static int32_t init(scap_t* handle, scap_open_args *oargs)
 {
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	int32_t rc = 0;
 	char bpf_probe_buf[SCAP_MAX_PATH_SIZE] = {0};
 	struct scap_engine_handle engine = handle->m_engine;

--- a/userspace/libscap/engine/gvisor/gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/gvisor.cpp
@@ -47,9 +47,21 @@ static SCAP_HANDLE_T *gvisor_alloc_handle(scap_t* main_handle, char *lasterr_ptr
 
 static int32_t gvisor_init(scap_t* main_handle, scap_open_args* oargs)
 {
+	int32_t ret;
 	scap_gvisor::engine *gv = main_handle->m_engine.m_handle;
 	struct scap_gvisor_engine_params *params = (struct scap_gvisor_engine_params *)oargs->engine_params;
-	return gv->init(params->gvisor_config_path, params->gvisor_root_path);
+	ret = gv->init(params->gvisor_config_path, params->gvisor_root_path);
+	if(ret != SCAP_SUCCESS)
+	{
+		return ret;
+	}
+
+	if(!oargs->no_events)
+	{
+		return gv->open_socket();
+	}
+
+	return SCAP_SUCCESS;
 }
 
 static void gvisor_free_handle(struct scap_engine_handle engine)

--- a/userspace/libscap/engine/gvisor/gvisor.h
+++ b/userspace/libscap/engine/gvisor/gvisor.h
@@ -133,6 +133,7 @@ public:
     engine(char *lasterr);
     ~engine();
     int32_t init(std::string config_path, std::string root_path);
+    int32_t open_socket();
     int32_t close();
 
     int32_t start_capture();

--- a/userspace/libscap/engine/gvisor/scap_gvisor.cpp
+++ b/userspace/libscap/engine/gvisor/scap_gvisor.cpp
@@ -136,8 +136,6 @@ int32_t engine::init(std::string config_path, std::string root_path)
 		return SCAP_FAILURE;
 	}
 
-	unlink(m_socket_path.c_str());
-	
 	// Check if runsc is installed in the system
 	runsc::result version = runsc::version();
 	if(version.error)
@@ -145,6 +143,13 @@ int32_t engine::init(std::string config_path, std::string root_path)
 		strlcpy(m_lasterr, "Cannot find runsc binary", SCAP_LASTERR_SIZE);
 		return SCAP_FAILURE;
 	}
+
+	return SCAP_SUCCESS;
+}
+
+int32_t engine::open_socket()
+{
+	unlink(m_socket_path.c_str());
 
 	int sock = socket(PF_UNIX, SOCK_SEQPACKET, 0);
 	if(sock == -1)

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -202,6 +202,11 @@ int32_t scap_kmod_handle_event_mask(struct scap_engine_handle engine, uint32_t o
 
 int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 {
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	struct scap_engine_handle engine = handle->m_engine;
 	struct scap_kmod_engine_params* params  = oargs->engine_params;
 	char filename[SCAP_MAX_PATH_SIZE] = {0};

--- a/userspace/libscap/engine/kmod/scap_kmod.c
+++ b/userspace/libscap/engine/kmod/scap_kmod.c
@@ -202,7 +202,6 @@ int32_t scap_kmod_handle_event_mask(struct scap_engine_handle engine, uint32_t o
 
 int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 {
-	uint32_t j = 0;
 	struct scap_engine_handle engine = handle->m_engine;
 	struct scap_kmod_engine_params* params  = oargs->engine_params;
 	char filename[SCAP_MAX_PATH_SIZE] = {0};
@@ -211,7 +210,6 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	int32_t rc = 0;
 
 	int mapped_len = 0;
-	uint32_t all_scanned_devs = 0;
 	uint64_t api_version = 0;
 	uint64_t schema_version = 0;
 
@@ -256,7 +254,7 @@ int32_t scap_kmod_init(scap_t *handle, scap_open_args *oargs)
 	mapped_len = single_buffer_dim * 2;
 
 	struct scap_device_set *devset = &engine.m_handle->m_dev_set;
-	for(j = 0, all_scanned_devs = 0; j < devset->m_ndevs && all_scanned_devs < ncpus; ++all_scanned_devs)
+	for(uint32_t j = 0, all_scanned_devs = 0; j < devset->m_ndevs && all_scanned_devs < ncpus; ++all_scanned_devs)
 	{
 		struct scap_device *dev = &devset->m_devs[j];
 

--- a/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
+++ b/userspace/libscap/engine/modern_bpf/scap_modern_bpf.c
@@ -214,6 +214,11 @@ int32_t scap_modern_bpf__init(scap_t* handle, scap_open_args* oargs)
 	struct scap_modern_bpf_engine_params* params = oargs->engine_params;
 	bool libbpf_verbosity = false;
 
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	pman_clear_state();
 
 	/* Some checks to test if we can use the modern BPF probe

--- a/userspace/libscap/engine/udig/scap_udig.c
+++ b/userspace/libscap/engine/udig/scap_udig.c
@@ -562,6 +562,11 @@ static int32_t init(scap_t* main_handle, scap_open_args* oargs)
 	struct udig_engine *handle = main_handle->m_engine.m_handle;
 	int rc;
 
+	if(oargs->no_events)
+	{
+		return SCAP_SUCCESS;
+	}
+
 	rc = devset_init(&handle->m_dev_set, 1, handle->m_lasterr);
 	if(rc != SCAP_SUCCESS)
 	{

--- a/userspace/libscap/scap-int.h
+++ b/userspace/libscap/scap-int.h
@@ -81,6 +81,8 @@ struct scap
 
 	// Function which may be called to log a debug event
 	void(*m_debug_log_fn)(const char* msg);
+
+	bool m_no_events;
 };
 
 typedef enum ppm_dumper_type

--- a/userspace/libscap/scap.c
+++ b/userspace/libscap/scap.c
@@ -93,6 +93,7 @@ scap_t* scap_open_live_int(char *error, int32_t *rc, scap_open_args* oargs, cons
 	handle->m_proc_scan_timeout_ms = oargs->proc_scan_timeout_ms;
 	handle->m_proc_scan_log_interval_ms = oargs->proc_scan_log_interval_ms;
 	handle->m_debug_log_fn = oargs->debug_log_fn;
+	handle->m_no_events = oargs->no_events;
 	//
 	// Extract machine information
 	//
@@ -889,7 +890,7 @@ scap_os_platform scap_get_os_platform(scap_t* handle)
 
 uint32_t scap_get_ndevs(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_n_devs(handle->m_engine);
 	}
@@ -905,7 +906,7 @@ int32_t scap_readbuf(scap_t* handle, uint32_t cpuid, OUT char** buf, OUT uint32_
 
 uint64_t scap_max_buf_used(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_max_buf_used(handle->m_engine);
 	}
@@ -915,7 +916,7 @@ uint64_t scap_max_buf_used(scap_t* handle)
 int32_t scap_next(scap_t* handle, OUT scap_evt** pevent, OUT uint16_t* pcpuid)
 {
 	int32_t res = SCAP_FAILURE;
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		res = handle->m_vtable->next(handle->m_engine, pevent, pcpuid);
 	}
@@ -985,7 +986,7 @@ int32_t scap_get_stats(scap_t* handle, OUT scap_stats* stats)
 	stats->n_suppressed = handle->m_suppress.m_num_suppressed_evts;
 	stats->n_tids_suppressed = HASH_COUNT(handle->m_suppress.m_suppressed_tids);
 
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_stats(handle->m_engine, stats);
 	}
@@ -1135,7 +1136,7 @@ unsigned long scap_get_system_page_size()
 //
 int32_t scap_stop_capture(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->stop_capture(handle->m_engine);
 	}
@@ -1150,7 +1151,7 @@ int32_t scap_stop_capture(scap_t* handle)
 //
 int32_t scap_start_capture(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->start_capture(handle->m_engine);
 	}
@@ -1162,7 +1163,7 @@ int32_t scap_start_capture(scap_t* handle)
 
 int32_t scap_enable_tracers_capture(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TRACERS_CAPTURE, 1, 0);
 	}
@@ -1174,7 +1175,7 @@ int32_t scap_enable_tracers_capture(scap_t* handle)
 
 int32_t scap_stop_dropping_mode(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, 1, 0);
 	}
@@ -1186,7 +1187,7 @@ int32_t scap_stop_dropping_mode(scap_t* handle)
 
 int32_t scap_start_dropping_mode(scap_t* handle, uint32_t sampling_ratio)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SAMPLING_RATIO, sampling_ratio, 1);
 	}
@@ -1232,7 +1233,7 @@ const scap_machine_info* scap_get_machine_info(scap_t* handle)
 
 int32_t scap_set_snaplen(scap_t* handle, uint32_t snaplen)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_SNAPLEN, snaplen, 0);
 	}
@@ -1282,7 +1283,7 @@ static int32_t scap_handle_ppm_sc_mask(scap_t* handle, uint32_t op, uint32_t ppm
 		return SCAP_FAILURE;
 	}
 
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_EVENTMASK, op, ppm_sc);
 	}
@@ -1326,7 +1327,7 @@ static int32_t scap_handle_tpmask(scap_t* handle, uint32_t op, uint32_t tp)
 		return SCAP_FAILURE;
 	}
 
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_TPMASK, op, tp);
 	}
@@ -1353,7 +1354,7 @@ uint32_t scap_event_get_dump_flags(scap_t* handle)
 
 int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 1, 0);
 	}
@@ -1364,7 +1365,7 @@ int32_t scap_enable_dynamic_snaplen(scap_t* handle)
 
 int32_t scap_disable_dynamic_snaplen(scap_t* handle)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_DYNAMIC_SNAPLEN, 0, 0);
 	}
@@ -1458,7 +1459,7 @@ void scap_fseek(scap_t *handle, uint64_t off)
 
 int32_t scap_get_n_tracepoint_hit(scap_t* handle, long* ret)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->get_n_tracepoint_hit(handle->m_engine, ret);
 	}
@@ -1488,7 +1489,7 @@ bool scap_check_suppressed_tid(scap_t *handle, int64_t tid)
 
 int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, uint16_t range_end)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_FULLCAPTURE_PORT_RANGE, range_start, range_end);
 	}
@@ -1499,7 +1500,7 @@ int32_t scap_set_fullcapture_port_range(scap_t* handle, uint16_t range_start, ui
 
 int32_t scap_set_statsd_port(scap_t* const handle, const uint16_t port)
 {
-	if(handle->m_vtable)
+	if(handle->m_vtable && !handle->m_no_events)
 	{
 		return handle->m_vtable->configure(handle->m_engine, SCAP_STATSD_PORT, port, 0);
 	}

--- a/userspace/libscap/scap_open.h
+++ b/userspace/libscap/scap_open.h
@@ -101,6 +101,7 @@ extern "C"
 		void(*debug_log_fn)(const char* msg); //< Function which SCAP may use to log a debug message
 		uint64_t proc_scan_timeout_ms; //< Timeout in msec, after which so-far-successful scan of /proc should be cut short with success return
 		uint64_t proc_scan_log_interval_ms; //< Interval for logging progress messages from /proc scan
+		bool no_events; //< Pinky swear we don't want any event from it (i.e. next will always fail, just have proc scan)
 		void* engine_params;			   ///< engine-specific params.
 	} scap_open_args;
 

--- a/userspace/libsinsp/event.cpp
+++ b/userspace/libsinsp/event.cpp
@@ -1725,8 +1725,7 @@ const char* sinsp_evt::get_param_as_str(uint32_t id, OUT const char** resolved_s
 					(char*)cwd.c_str(),
 					(uint32_t)cwd.length(),
 					payload,
-					payload_len,
-					m_inspector->m_is_windows))
+					payload_len))
 				{
 					m_resolved_paramstr_storage[0] = 0;
 				}

--- a/userspace/libsinsp/examples/test.cpp
+++ b/userspace/libsinsp/examples/test.cpp
@@ -160,10 +160,13 @@ void open_engine(sinsp& inspector)
 	/* Get only necessary tracepoints. */
 	std::unordered_set<uint32_t> tp_set = inspector.enforce_sinsp_state_tp();
 	std::unordered_set<uint32_t> ppm_sc;
+	struct sinsp_driver_params params = {};
+	params.set_ppm_sc_of_interest(std::move(ppm_sc));
+	params.set_tp_of_interest(std::move(tp_set));
 
 	if(!engine_string.compare(KMOD_ENGINE))
 	{
-		inspector.open_kmod(buffer_bytes_dim, ppm_sc, tp_set);
+		inspector.open_kmod(buffer_bytes_dim, &params);
 	}
 	else if(!engine_string.compare(BPF_ENGINE))
 	{
@@ -176,7 +179,7 @@ void open_engine(sinsp& inspector)
 		{
 			std::cerr << bpf_path << std::endl;
 		}
-		inspector.open_bpf(bpf_path.c_str(), buffer_bytes_dim, ppm_sc, tp_set);
+		inspector.open_bpf(bpf_path.c_str(), buffer_bytes_dim, &params);
 	}
 	else if(!engine_string.compare(SAVEFILE_ENGINE))
 	{
@@ -185,11 +188,11 @@ void open_engine(sinsp& inspector)
 			std::cerr << "You must specify the path to the file if you use the 'savefile' engine" << std::endl;
 			exit(EXIT_FAILURE);
 		}
-		inspector.open_savefile(file_path.c_str(), 0);
+		inspector.open_savefile(file_path.c_str(), 0, &params);
 	}
 	else if(!engine_string.compare(MODERN_BPF_ENGINE))
 	{
-		inspector.open_modern_bpf(buffer_bytes_dim, DEFAULT_CPU_FOR_EACH_BUFFER, true, ppm_sc, tp_set);
+		inspector.open_modern_bpf(buffer_bytes_dim, DEFAULT_CPU_FOR_EACH_BUFFER, true, &params);
 	}
 	else
 	{

--- a/userspace/libsinsp/filterchecks.cpp
+++ b/userspace/libsinsp/filterchecks.cpp
@@ -263,8 +263,7 @@ bool sinsp_filter_check_fd::extract_fdname_from_creator(sinsp_evt *evt, OUT uint
 				sdir.c_str(),
 				(uint32_t)sdir.length(),
 				name,
-				namelen,
-				m_inspector->m_is_windows);
+				namelen);
 
 			if(fd_nameraw)
 			{
@@ -3534,7 +3533,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 			parinfo = evt->get_param(3);
 
 			sinsp_utils::concatenate_paths(fullname, SCAP_MAX_PATH_SIZE, "", 0,
-				parinfo->m_val, parinfo->m_len, m_inspector->m_is_windows);
+				parinfo->m_val, parinfo->m_len);
 
 			m_strstorage = fullname;
 			RETURN_EXTRACT_STRING(m_strstorage);
@@ -3642,7 +3641,7 @@ uint8_t *sinsp_filter_check_event::extract_abspath(sinsp_evt *evt, OUT uint32_t 
 
 	char fullname[SCAP_MAX_PATH_SIZE];
 	sinsp_utils::concatenate_paths(fullname, SCAP_MAX_PATH_SIZE, sdir.c_str(),
-		(uint32_t)sdir.length(), path, pathlen, m_inspector->m_is_windows);
+		(uint32_t)sdir.length(), path, pathlen);
 
 	m_strstorage = fullname;
 

--- a/userspace/libsinsp/parsers.cpp
+++ b/userspace/libsinsp/parsers.cpp
@@ -1426,11 +1426,6 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 
 	if(!(tinfo->m_flags & PPM_CL_CLONE_THREAD))
 	{
-		if(m_inspector->m_is_windows)
-		{
-			tinfo->m_flags |= PPM_CL_IS_MAIN_THREAD;
-		}
-
 		//
 		// Copy the fd list
 		// XXX this is a gross oversimplification that will need to be fixed.
@@ -1465,22 +1460,7 @@ void sinsp_parser::parse_clone_exit(sinsp_evt *evt)
 		//
 		// Not a thread, copy cwd
 		//
-		if(m_inspector->m_is_windows)
-		{
-			if(ptinfo->m_tid == 0 && ptinfo->m_pid == 0)
-			{
-				parinfo = evt->get_param(6);
-				tinfo->m_cwd = parinfo->m_val;
-			}
-			else
-			{
-				tinfo->m_cwd = ptinfo->get_cwd();
-			}
-		}
-		else
-		{
-			tinfo->m_cwd = ptinfo->get_cwd();
-		}
+		tinfo->m_cwd = ptinfo->get_cwd();
 	}
 	//if((tinfo->m_flags & (PPM_CL_CLONE_FILES)))
 	//{
@@ -2003,8 +1983,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 												evt->m_tinfo->m_cwd.c_str(),
 												(uint32_t)evt->m_tinfo->m_cwd.size(),
 												parinfo->m_val,
-												(uint32_t)parinfo->m_len,
-												m_inspector->m_is_windows);
+												(uint32_t)parinfo->m_len);
 			}
 		}
 		else if(enter_evt->get_type() == PPME_SYSCALL_EXECVEAT_E)
@@ -2072,8 +2051,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 								"\0", 
 								0,
 								sdir.c_str(), 
-								(uint32_t)sdir.length(), 
-								m_inspector->m_is_windows);
+								(uint32_t)sdir.length());
 
 			}
 			/* (2)/(1) If it is relative or absolute we craft the `fullpath` as usual:
@@ -2085,8 +2063,7 @@ void sinsp_parser::parse_execve_exit(sinsp_evt *evt)
 											sdir.c_str(), 
 											(uint32_t)sdir.length(),
 											pathname, 
-											namelen, 
-											m_inspector->m_is_windows);
+											namelen);
 			}
 		}
 		evt->m_tinfo->m_exepath = fullpath;
@@ -2668,7 +2645,7 @@ void sinsp_parser::parse_open_openat_creat_exit(sinsp_evt *evt)
 	char fullpath[SCAP_MAX_PATH_SIZE];
 
 	sinsp_utils::concatenate_paths(fullpath, SCAP_MAX_PATH_SIZE, sdir.c_str(), (uint32_t)sdir.length(),
-		name, namelen, m_inspector->m_is_windows);
+		name, namelen);
 
 	if(fd >= 0)
 	{

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -489,14 +489,6 @@ void sinsp::open_common(scap_open_args* oargs)
 	init();
 }
 
-scap_open_args sinsp::factory_open_args(const char* engine_name, scap_mode_t scap_mode)
-{
-	scap_open_args oargs{};
-	oargs.engine_name = engine_name;
-	oargs.mode = scap_mode;
-	return oargs;
-}
-
 void sinsp::open_kmod(unsigned long driver_buffer_bytes_dim, sinsp_driver_params* driver_params)
 {
 	sinsp_driver_params p = {};

--- a/userspace/libsinsp/sinsp.cpp
+++ b/userspace/libsinsp/sinsp.cpp
@@ -327,13 +327,6 @@ void sinsp::init()
 	}
 
 	//
-	// XXX
-	// This will need to be integrated in the machine info
-	//
-	scap_os_platform platform = scap_get_os_platform(m_h);
-	m_is_windows = (platform == SCAP_PFORM_WINDOWS_I386 || platform == SCAP_PFORM_WINDOWS_X64);
-
-	//
 	// Attach the protocol decoders
 	//
 #ifndef HAS_ANALYZER

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -196,6 +196,20 @@ public:
  @{
 */
 
+struct SINSP_PUBLIC sinsp_driver_params : public scap_open_args
+{
+	sinsp_driver_params& set_ppm_sc_of_interest(const std::unordered_set<uint32_t>& s)
+	{
+		fill_ppm_sc_of_interest(this, s);
+		return *this;
+	}
+	sinsp_driver_params& set_tp_of_interest(const std::unordered_set<uint32_t>& s)
+	{
+		fill_tp_of_interest(this, s);
+		return *this;
+	}
+};
+
 /*!
   \brief System inspector class.
   This is the library entry point class. The functionality it exports includes:
@@ -220,19 +234,19 @@ public:
 
 
 	/* Wrappers to open a specific engine. */
-	virtual void open_kmod(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
-	virtual void open_bpf(const std::string &bpf_path, unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
-	virtual void open_udig();
-	virtual void open_nodriver();
-	virtual void open_savefile(const std::string &filename, int fd = 0);
-	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params);
-	virtual void open_gvisor(const std::string &config_path, const std::string &root_path);
+	virtual void open_kmod(unsigned long driver_buffer_bytes_dim, sinsp_driver_params* driver_params = nullptr);
+	virtual void open_bpf(const std::string& bpf_path, unsigned long driver_buffer_bytes_dim, sinsp_driver_params* driver_params = nullptr);
+	virtual void open_udig(sinsp_driver_params* driver_params = nullptr);
+	virtual void open_nodriver(sinsp_driver_params* driver_params = nullptr);
+	virtual void open_savefile(const std::string &filename, int fd = 0, sinsp_driver_params* driver_params = nullptr);
+	virtual void open_plugin(const std::string &plugin_name, const std::string &plugin_open_params, sinsp_driver_params* driver_params = nullptr);
+	virtual void open_gvisor(const std::string &config_path, const std::string &root_path, sinsp_driver_params* driver_params = nullptr);
 	/*[EXPERIMENTAL] This API could change between releases, we are trying to find the right configuration to deploy the modern bpf probe:
 	 * `cpus_for_each_buffer` and `online_only` are the 2 experimental params. The first one allows associating more than one CPU to a single ring buffer.
 	 * The last one allows allocating ring buffers only for online CPUs and not for all system-available CPUs.
 	 */
-	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, const std::unordered_set<uint32_t> &ppm_sc_of_interest = {}, const std::unordered_set<uint32_t> &tp_of_interest = {});
-	virtual void open_test_input(scap_test_input_data *data);
+	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, sinsp_driver_params* driver_params = nullptr);
+	virtual void open_test_input(scap_test_input_data *data, sinsp_driver_params* driver_params = nullptr);
 
 	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);
 

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -52,6 +52,7 @@ limitations under the License.
 #include "sinsp_inet.h"
 #include "sinsp_public.h"
 #include "sinsp_exception.h"
+#include "sinsp_ppm_sc.h"
 
 #include <string>
 #include <map>
@@ -1196,7 +1197,6 @@ private:
 	void add_protodecoders();
 	void remove_thread(int64_t tid, bool force);
 
-	void fill_ppm_sc_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &ppm_sc_of_interest);
 	void fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &tp_of_interest);
 
 	//

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -1269,7 +1269,6 @@ private:
 	// <m_input_fd>". Otherwise, reading from m_input_filename.
 	int m_input_fd;
 	std::string m_input_filename;
-	bool m_is_windows;
 	bool m_isdebug_enabled;
 	bool m_isfatfile_enabled;
 	bool m_isinternal_events_enabled;

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -208,6 +208,11 @@ struct SINSP_PUBLIC sinsp_driver_params : public scap_open_args
 		fill_tp_of_interest(this, s);
 		return *this;
 	}
+	sinsp_driver_params& set_no_events(bool f)
+	{
+		no_events = f;
+		return *this;
+	}
 };
 
 /*!

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -53,6 +53,7 @@ limitations under the License.
 #include "sinsp_public.h"
 #include "sinsp_exception.h"
 #include "sinsp_ppm_sc.h"
+#include "sinsp_tp.h"
 
 #include <string>
 #include <map>
@@ -1196,8 +1197,6 @@ private:
 	void import_user_list();
 	void add_protodecoders();
 	void remove_thread(int64_t tid, bool force);
-
-	void fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &tp_of_interest);
 
 	//
 	// Note: lookup_only should be used when the query for the thread is made

--- a/userspace/libsinsp/sinsp.h
+++ b/userspace/libsinsp/sinsp.h
@@ -248,8 +248,6 @@ public:
 	virtual void open_modern_bpf(unsigned long driver_buffer_bytes_dim = DEFAULT_DRIVER_BUFFER_BYTES_DIM, uint16_t cpus_for_each_buffer = DEFAULT_CPU_FOR_EACH_BUFFER, bool online_only = true, sinsp_driver_params* driver_params = nullptr);
 	virtual void open_test_input(scap_test_input_data *data, sinsp_driver_params* driver_params = nullptr);
 
-	scap_open_args factory_open_args(const char* engine_name, scap_mode_t scap_mode);
-
 	std::string generate_gvisor_config(std::string socket_path);
 
 

--- a/userspace/libsinsp/sinsp_ppm_sc.cpp
+++ b/userspace/libsinsp/sinsp_ppm_sc.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <sinsp.h>
 
-void sinsp::fill_ppm_sc_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &ppm_sc_of_interest)
+void fill_ppm_sc_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &ppm_sc_of_interest)
 {
 	for (int i = 0; i < PPM_SC_MAX; i++)
 	{

--- a/userspace/libsinsp/sinsp_ppm_sc.h
+++ b/userspace/libsinsp/sinsp_ppm_sc.h
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <unordered_set>
+
+struct scap_open_args;
+
+void fill_ppm_sc_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &ppm_sc_of_interest);

--- a/userspace/libsinsp/sinsp_tp.cpp
+++ b/userspace/libsinsp/sinsp_tp.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include <sinsp.h>
 
-void sinsp::fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &tp_of_interest)
+void fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &tp_of_interest)
 {
 	for(int i = 0; i < TP_VAL_MAX; i++)
 	{

--- a/userspace/libsinsp/sinsp_tp.h
+++ b/userspace/libsinsp/sinsp_tp.h
@@ -1,0 +1,25 @@
+/*
+Copyright (C) 2023 The Falco Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <unordered_set>
+
+struct scap_open_args;
+
+void fill_tp_of_interest(scap_open_args *oargs, const std::unordered_set<uint32_t> &tp_of_interest);

--- a/userspace/libsinsp/threadinfo.cpp
+++ b/userspace/libsinsp/threadinfo.cpp
@@ -912,8 +912,7 @@ void sinsp_threadinfo::set_cwd(const char* cwd, uint32_t cwdlen)
 			(char*)tinfo->m_cwd.c_str(),
 			(uint32_t)tinfo->m_cwd.size(),
 			cwd,
-			cwdlen,
-			m_inspector->m_is_windows);
+			cwdlen);
 
 		tinfo->m_cwd = tpath;
 

--- a/userspace/libsinsp/utils.cpp
+++ b/userspace/libsinsp/utils.cpp
@@ -754,8 +754,7 @@ bool sinsp_utils::concatenate_paths(char* target,
 									const char* path1,
 									uint32_t len1,
 									const char* path2,
-									uint32_t len2,
-									bool windows_paths)
+									uint32_t len2)
 {
 	if(targetlen < (len1 + len2 + 1))
 	{
@@ -763,35 +762,17 @@ bool sinsp_utils::concatenate_paths(char* target,
 		return false;
 	}
 
-	if(windows_paths)
+	if(len2 != 0 && path2[0] != '/')
 	{
-		if(len2 != 0 && path2[0] != '\\' && path2[1] != ':')
-		{
-			memcpy(target, path1, len1);
-			copy_and_sanitize_path(target + len1, target, path2, '\\');
-			return true;
-		}
-		else
-		{
-			target[0] = 0;
-			copy_and_sanitize_path(target, target, path2, '\\');
-			return false;
-		}
+		memcpy(target, path1, len1);
+		copy_and_sanitize_path(target + len1, target, path2, '/');
+		return true;
 	}
 	else
 	{
-		if(len2 != 0 && path2[0] != '/')
-		{
-			memcpy(target, path1, len1);
-			copy_and_sanitize_path(target + len1, target, path2, '/');
-			return true;
-		}
-		else
-		{
-			target[0] = 0;
-			copy_and_sanitize_path(target, target, path2, '/');
-			return false;
-		}
+		target[0] = 0;
+		copy_and_sanitize_path(target, target, path2, '/');
+		return false;
 	}
 }
 

--- a/userspace/libsinsp/utils.h
+++ b/userspace/libsinsp/utils.h
@@ -92,9 +92,8 @@ public:
 	// If path2 is relative, the concatenation happens and the result is true.
 	// If path2 is absolute, the concatenation does not happen, target contains path2 and the result is false.
 	// Assumes that path1 is well formed.
-	// Supports both unix and windows paths. Use the windows_paths argument to specify which one you want.
 	//
-	static bool concatenate_paths(char* target, uint32_t targetlen, const char* path1, uint32_t len1, const char* path2, uint32_t len2, bool windows_paths);
+	static bool concatenate_paths(char* target, uint32_t targetlen, const char* path1, uint32_t len1, const char* path2, uint32_t len2);
 
 	//
 	// Determines if an IPv6 address is IPv4-mapped


### PR DESCRIPTION
This new scap_open_args flag means that we're *not* going to get any events from the engine and are using it just for the secondary effects of scap_open (mostly getting the process table).