### PR TITLE
cleanup(build): Use a single cmake module for driver_config.h

### DIFF
--- a/cmake/modules/driver_config.cmake
+++ b/cmake/modules/driver_config.cmake
@@ -1,0 +1,14 @@
+include(compute_versions RESULT_VARIABLE RESULT)
+if(RESULT STREQUAL NOTFOUND)
+    message(FATAL_ERROR "problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
+endif()
+
+set(DRIVER_CONFIG_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../driver)
+get_filename_component(DRIVER_CONFIG_OUTPUT_DIR ${CMAKE_BINARY_DIR}/driver_config ABSOLUTE)
+
+compute_versions(${DRIVER_CONFIG_SOURCE_DIR}/API_VERSION ${DRIVER_CONFIG_SOURCE_DIR}/SCHEMA_VERSION)
+configure_file(${DRIVER_CONFIG_SOURCE_DIR}/driver_config.h.in ${DRIVER_CONFIG_OUTPUT_DIR}/driver_config.h.tmp)
+execute_process(
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different driver_config.h.tmp driver_config.h
+        WORKING_DIRECTORY ${DRIVER_CONFIG_OUTPUT_DIR}
+)

--- a/cmake/modules/libscap.cmake
+++ b/cmake/modules/libscap.cmake
@@ -35,7 +35,7 @@ else()
 endif()
 
 get_filename_component(LIBSCAP_INCLUDE_DIR ${LIBSCAP_DIR}/userspace/libscap ABSOLUTE)
-set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR} ${DRIVER_CONFIG_DIR})
+set(LIBSCAP_INCLUDE_DIRS ${LIBSCAP_INCLUDE_DIR})
 
 function(set_scap_target_properties target)
 	set_target_properties(${target} PROPERTIES

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -80,15 +80,9 @@ endif()
 # ${CMAKE_CURRENT_BINARY_DIR}/src. To maintain compatibility with older versions,
 # after the build we copy the compiled module one directory up,
 # to ${CMAKE_CURRENT_BINARY_DIR}.
-include(compute_versions RESULT_VARIABLE RESULT)
-if(RESULT STREQUAL NOTFOUND)
-  message(FATAL_ERROR "problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
-endif()
-compute_versions(API_VERSION SCHEMA_VERSION)
-
 configure_file(dkms.conf.in src/dkms.conf)
 configure_file(Makefile.in src/Makefile)
-configure_file(driver_config.h.in src/driver_config.h)
+include(driver_config)
 
 set(DRIVER_SOURCES
 	dynamic_params_table.c
@@ -160,7 +154,7 @@ add_custom_target(install_driver
 if(ENABLE_DKMS)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/Makefile
 		${CMAKE_CURRENT_BINARY_DIR}/src/dkms.conf
-		${CMAKE_CURRENT_BINARY_DIR}/src/driver_config.h
+		${CMAKE_BINARY_DIR}/driver_config/driver_config.h
 		${DRIVER_SOURCES}
 		DESTINATION "src/${DRIVER_PACKAGE_NAME}-${DRIVER_VERSION}"
 		COMPONENT ${DRIVER_COMPONENT_NAME})

--- a/driver/bpf/CMakeLists.txt
+++ b/driver/bpf/CMakeLists.txt
@@ -5,7 +5,7 @@
 # MIT.txt or GPL.txt for full copies of the license.
 #
 
-configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
+include(driver_config)
 
 option(BUILD_BPF "Build the BPF driver on Linux" OFF)
 

--- a/driver/modern_bpf/CMakeLists.txt
+++ b/driver/modern_bpf/CMakeLists.txt
@@ -37,7 +37,6 @@ if(RESULT STREQUAL NOTFOUND)
   message(FATAL_ERROR "${MODERN_BPF_LOG_PREFIX} problem with compute_versions.cmake in ${CMAKE_MODULE_PATH}")
 endif()
 compute_versions(../API_VERSION ../SCHEMA_VERSION)
-configure_file(../driver_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/../driver_config.h)
 
 ########################
 # Check clang version.

--- a/userspace/libscap/engine/bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/bpf/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include(driver_config)
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_OUTPUT_DIR} ../noop)
 add_library(scap_engine_bpf scap_bpf.c attached_prog.c)
 add_dependencies(scap_engine_bpf libelf scap_platform)
 target_link_libraries(scap_engine_bpf scap_event_schema scap_platform scap_engine_util scap_error ${LIBELF_LIB})

--- a/userspace/libscap/engine/kmod/CMakeLists.txt
+++ b/userspace/libscap/engine/kmod/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories(${LIBSCAP_INCLUDE_DIRS})
+include(driver_config)
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_OUTPUT_DIR})
 add_library(scap_engine_kmod scap_kmod.c)
 target_link_libraries(scap_engine_kmod scap_event_schema scap_platform scap_engine_util scap_error)
 add_dependencies(scap_engine_kmod scap_event_schema scap_platform scap_engine_util scap_error)

--- a/userspace/libscap/engine/modern_bpf/CMakeLists.txt
+++ b/userspace/libscap/engine/modern_bpf/CMakeLists.txt
@@ -1,4 +1,5 @@
-include_directories(${LIBSCAP_INCLUDE_DIRS} ../noop)
+include(driver_config)
+include_directories(${LIBSCAP_INCLUDE_DIRS} ${DRIVER_CONFIG_OUTPUT_DIR} ../noop)
 
 message(STATUS "Build modern BPF engine")
 option(USE_BUNDLED_MODERN_BPF "use bundled modern BPF" ON)


### PR DESCRIPTION
Instead of manually generating driver_config.h when needed (approximately, since the libscap engines do not generate it, even though they rely on it), encapsulate all the logic in a single cmake module.

Note: this removes the driver_config directory from LIBSCAP_INCLUDE_DIRS. If you actually need driver_config.h, add this to your CMakeLists.txt:

    include(driver_config)
    include_directories(${DRIVER_CONFIG_OUTPUT_DIR})


Upstream PR: https://github.com/falcosecurity/libs/pull/1188